### PR TITLE
Add the team as approvers and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,24 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - codificat
   - fridex
   - goern
+  - harshad16
+  - kpostoffice
+  - mayaCostantini
+  - pacospace
   - sesheta
 
 reviewers:
+  - codificat
+  - fridex
+  - goern
   - harshad16
-  - pacespace
   - kpostoffice
+  - mayaCostantini
+  - pacospace
 
 labels:
   - sig/user-experience
-  - sig/cyborgs
+  - sig/docs


### PR DESCRIPTION
This is to add the core team as both approvers and reviewers for this repository.

Also, not sure why `sig/cyborgs` was listed as a label here. In any case, I believe this is not an active SIG, so replacing it with the (I think) more relevant here `sig/docs`.