### PR TITLE
Enable prow in the repo with a basic pre-commit check

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,2 @@
+check:
+  - thoth-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-merge-conflict

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.10
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"


### PR DESCRIPTION
Prow is not working on this repo, requiring org members with enough permissions to manually merge PRs.

This PR adds configuration so that `/approve` and similar comments can be used to manage PRs